### PR TITLE
chore: remove link to previous http server package and reference @dcl/http-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/decentraland/platform-server-commons#readme",
   "dependencies": {
+    "@dcl/http-server": "^1.0.0",
     "@dcl/schemas": "^18.0.0",
-    "@dcl/wkc-http-server": "^1.0.3",
     "@well-known-components/interfaces": "^1.4.3",
     "node-fetch": "^2.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,20 +383,10 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
-"@dcl/schemas@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-18.0.0.tgz#f4df29b31e998e4c8e51dfb2ec106b7b1e4a6581"
-  integrity sha512-RGG7TUjLslzpsej177CK79WlPKfaAH0SXtW3fYV2btNs93mB6ppGLAh8fx6GBy7kErVBflFRenQFWLJ1gsrNrQ==
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
-    mitt "^3.0.1"
-
-"@dcl/wkc-http-server@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@dcl/wkc-http-server/-/wkc-http-server-1.0.3.tgz#fd43a4bf1a1e26461ee59447d9e22f6bd636b72e"
-  integrity sha512-3Pi4VlalpoRymoVCEkqNVHQtLTkK4hVSmyS7gQdpKRktJnWwl9JoUeARDpbffsRwD3/485mDAQvIA3HE7v7uqA==
+"@dcl/http-server@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-1.0.0.tgz#202fe016e755ac9798668051f466fe496737c232"
+  integrity sha512-Dq7hjrOfwUY2VztmZlk70OwOFkwiLO360BgJw4h2BFfYc0RACmw7TFI/uq/nHMJPNSs2Zi1htzuWQQsPAg1RQw==
   dependencies:
     "@types/http-errors" "^2.0.4"
     destroy "^1.2.0"
@@ -407,6 +397,16 @@
     on-finished "^2.4.1"
     path-to-regexp "^6.3.0"
     reflect-metadata "^0.2.2"
+
+"@dcl/schemas@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-18.0.0.tgz#f4df29b31e998e4c8e51dfb2ec106b7b1e4a6581"
+  integrity sha512-RGG7TUjLslzpsej177CK79WlPKfaAH0SXtW3fYV2btNs93mB6ppGLAh8fx6GBy7kErVBflFRenQFWLJ1gsrNrQ==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"


### PR DESCRIPTION
Replace packages references to use the new `@dcl/http-server` package.